### PR TITLE
feat: add GetAppointmentMessages request class

### DIFF
--- a/src/Requests/GetAppointmentMessages.php
+++ b/src/Requests/GetAppointmentMessages.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ChrisReedIO\HealthNoteSDK\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class GetAppointmentMessages extends Request
+{
+    protected Method $method = Method::GET;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/link/messages';
+    }
+
+    public function __construct(
+        protected string $patient_id,
+        protected string $appointment_id
+    ) {
+    }
+
+    public function defaultQuery(): array
+    {
+        return [
+            'patientId' => $this->patient_id,
+            'appointmentId' => $this->appointment_id,
+        ];
+    }
+}


### PR DESCRIPTION
Create a new request class to fetch messages for a specific appointment. This class will make it easier for developers to retrieve appointment-related messages by encapsulating the necessary query parameters within the request, thus streamlining the development process.